### PR TITLE
Fix #2  NPE when used with Log4J2-JPL

### DIFF
--- a/src/main/java/robaho/net/httpserver/ServerImpl.java
+++ b/src/main/java/robaho/net/httpserver/ServerImpl.java
@@ -131,7 +131,7 @@ class ServerImpl {
         this.wrapper = wrapper;
 
         this.logger = System.getLogger("robaho.net.httpserver."+System.identityHashCode(this));
-        LogManager.getLogManager().getLogger(this.logger.getName()).setFilter(new java.util.logging.Filter(){
+        java.util.logging.Logger.getLogger(this.logger.getName()).setFilter(new java.util.logging.Filter(){
             @Override
             public boolean isLoggable(LogRecord record) {
                 record.setMessage("["+protocol+":"+socket.getLocalPort()+"] "+record.getMessage());
@@ -182,7 +182,7 @@ class ServerImpl {
 
             var rc = requestCount.get();
 
-            var output = 
+            var output =
                 (
                 "Connections: "+connectionCount.get()+"\n" +
                 "Active Connections: "+allConnections.size()+"\n" +


### PR DESCRIPTION
This little patch solved the Log4J bridge problem for me. LogManager.getLogger(name) returns NULL, if the logger did not exist before - Logger.getLogger(name) does create an eventually not yet existing logger or returns the existing one.

Thank you for creating this project - it helps me preventing the bloat from full blown webserver frameworks.