### PR TITLE
final class for ActivityTimer, ChunkedInputStream, ChunkedOutputStream

### DIFF
--- a/src/main/java/robaho/net/httpserver/ActivityTimer.java
+++ b/src/main/java/robaho/net/httpserver/ActivityTimer.java
@@ -6,7 +6,7 @@ import java.time.format.TextStyle;
 import java.util.Locale;
 import java.util.TimerTask;
 
-class ActivityTimer {
+final class ActivityTimer {
     private static volatile long now = System.currentTimeMillis();
     private static volatile String dateAndTime = formatDate();
 
@@ -39,14 +39,14 @@ class ActivityTimer {
         return sb.toString();
     }
 
-    public static long now() {
+    static long now() {
         return now;
     }
     /**
      * return the formatted current date and time suitable for use with the Date http header. this
      * is OK to cache since the resolution is only seconds, and we will update more often than that
      */
-    public static String dateAndTime() {
+    static String dateAndTime() {
         return dateAndTime;
     }
 

--- a/src/main/java/robaho/net/httpserver/ChunkedInputStream.java
+++ b/src/main/java/robaho/net/httpserver/ChunkedInputStream.java
@@ -27,7 +27,7 @@ package robaho.net.httpserver;
 
 import java.io.*;
 
-class ChunkedInputStream extends LeftOverInputStream {
+final class ChunkedInputStream extends LeftOverInputStream {
     ChunkedInputStream(ExchangeImpl t, InputStream src) {
         super(t, src);
     }
@@ -107,6 +107,7 @@ class ChunkedInputStream extends LeftOverInputStream {
         throw new IOException("end of stream reading chunk header");
     }
 
+    @Override
     protected int readImpl(byte[] b, int off, int len) throws IOException {
         if (eof) {
             return -1;
@@ -154,6 +155,7 @@ class ChunkedInputStream extends LeftOverInputStream {
      * limitation for the moment. It only affects potential efficiency
      * rather than correctness.
      */
+    @Override
     public int available() throws IOException {
         if (eof || closed) {
             return 0;
@@ -162,13 +164,16 @@ class ChunkedInputStream extends LeftOverInputStream {
         return n > remaining ? remaining : n;
     }
 
+    @Override
     public boolean markSupported() {
         return false;
     }
 
+    @Override
     public void mark(int l) {
     }
 
+    @Override
     public void reset() throws IOException {
         throw new IOException("mark/reset not supported");
     }

--- a/src/main/java/robaho/net/httpserver/ChunkedOutputStream.java
+++ b/src/main/java/robaho/net/httpserver/ChunkedOutputStream.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * 0\r\n\r\n
  */
 
-class ChunkedOutputStream extends FilterOutputStream {
+final class ChunkedOutputStream extends FilterOutputStream {
     private boolean closed = false;
     /* max. amount of user data per chunk */
     static final int CHUNK_SIZE = 4096;
@@ -61,6 +61,7 @@ class ChunkedOutputStream extends FilterOutputStream {
         this.t = t;
     }
 
+    @Override
     public void write(int b) throws IOException {
         if (closed) {
             throw new StreamClosedException();
@@ -73,6 +74,7 @@ class ChunkedOutputStream extends FilterOutputStream {
         assert count < CHUNK_SIZE;
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         Objects.checkFromIndexSize(off, len, b.length);
         if (len == 0) {
@@ -128,6 +130,7 @@ class ChunkedOutputStream extends FilterOutputStream {
         pos = OFFSET;
     }
 
+    @Override
     public void close() throws IOException {
         if (closed) {
             return;
@@ -149,6 +152,7 @@ class ChunkedOutputStream extends FilterOutputStream {
         }
     }
 
+    @Override
     public void flush() throws IOException {
         if (closed) {
             throw new StreamClosedException();


### PR DESCRIPTION
Make ActivityTimer, ChunkedInputStream, ChunkedOutputStream `final` classes 

As these are using default modifier / package private we can also remove `public` from some of their methods.