### PR TITLE
Make extras classes final, not intended for extension

### DIFF
--- a/src/main/java/robaho/net/httpserver/extras/ContentEncoding.java
+++ b/src/main/java/robaho/net/httpserver/extras/ContentEncoding.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.sun.net.httpserver.Headers;
 
-public class ContentEncoding {
+public final class ContentEncoding {
 
     private static final String defaultCharset = StandardCharsets.ISO_8859_1.name();
 

--- a/src/main/java/robaho/net/httpserver/extras/FormParser.java
+++ b/src/main/java/robaho/net/httpserver/extras/FormParser.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * Parse url-encoded requests.
  */
-public class FormParser {
+public final class FormParser {
 
     // Sets the maximum count of accepted POST params - protection against Hash collision DOS attacks
     private static final int MAX_PARAMS = Integer.getInteger("robaho.net.httpserver.max_form_params", 1000); // 0 == no limit

--- a/src/main/java/robaho/net/httpserver/extras/MultipartFormParser.java
+++ b/src/main/java/robaho/net/httpserver/extras/MultipartFormParser.java
@@ -22,7 +22,7 @@ import robaho.net.httpserver.NoSyncBufferedOutputStream;
 /**
  * parse multipart form data
  */
-public class MultipartFormParser {
+public final class MultipartFormParser {
     /**
      * a multipart part.
      *

--- a/src/main/java/robaho/net/httpserver/extras/QueryParameters.java
+++ b/src/main/java/robaho/net/httpserver/extras/QueryParameters.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 
-public class QueryParameters extends LinkedHashMap<String, List<String>> {
+public final class QueryParameters extends LinkedHashMap<String, List<String>> {
 
     /**
      * @param encoding a valid java character set name


### PR DESCRIPTION
We can make these classes final with the view that they are not intended to be extended or only have static methods.